### PR TITLE
fix errors and warnings with Node.js v12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,8 @@ pack:
 		nvm exec 6 npm run prebuilt-bindings -- clean build pack && \
 		nvm exec 7 npm run prebuilt-bindings -- clean build pack && \
 		nvm exec 8 npm run prebuilt-bindings -- clean build pack && \
-		nvm exec 9 npm run prebuilt-bindings -- clean build pack \
+		nvm exec 9 npm run prebuilt-bindings -- clean build pack && \
+		nvm exec 10 npm run prebuilt-bindings -- clean build pack && \
+		nvm exec 11 npm run prebuilt-bindings -- clean build pack && \
+		nvm exec 12 npm run prebuilt-bindings -- clean build pack \
 	)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
     "nan": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
     },
     "prebuilt-bindings": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "bindings": "^1.3.0",
-    "nan": "^2.7.0",
+    "nan": "^2.13.2",
     "prebuilt-bindings": "^1.0.3"
   }
 }

--- a/src/launchd.cc
+++ b/src/launchd.cc
@@ -4,7 +4,8 @@
 v8::Local<v8::Value> complain(const char *msg, const char *code) {
   v8::Local<v8::Value> ex = Nan::Error(msg);
   v8::Local<v8::Object> obj = ex.As<v8::Object>();
-  obj->Set(
+  Nan::Set(
+    obj,
     Nan::New<v8::String>("code").ToLocalChecked(),
     Nan::New<v8::String>(code).ToLocalChecked()
   );
@@ -16,7 +17,7 @@ NAN_METHOD(Collect) {
     return Nan::ThrowError(Nan::TypeError("Must be given exactly 1 argument"));
   }
 
-  Nan::Utf8String handleName(info[0]->ToString());
+  Nan::Utf8String handleName(info[0]);
   int *fds;
   size_t cnt;
 


### PR DESCRIPTION
Thanks for this very useful library.

Node 10 & 11 had some warnings. Node 12 finally broke compatibility. This patch restores support for all versions 4 through 12 and cleans up any warnings.

Would also love it if you could publish the node-prebuilt-bindings packages for all node versions. Updated the Makefile accordingly. 🙏🏻